### PR TITLE
Use unit id for key on out of stock array in product selector

### DIFF
--- a/src/Controller/Module/Bundle/ProductSelector.php
+++ b/src/Controller/Module/Bundle/ProductSelector.php
@@ -201,7 +201,6 @@ class ProductSelector extends Controller
 	private function _getUnits(Product $product, array $options)
 	{
 		$units = [];
-		$outOfStock = [];
 
 		$locations = $this->get('stock.locations');
 
@@ -212,15 +211,11 @@ class ProductSelector extends Controller
 			}
 
 			if (1 > $unit->getStockForLocation($locations->getRoleLocation($locations::SELL_ROLE))) {
-				$outOfStock[] = $unit->id;
+				$this->_outOfStock[(int) $unit->id] = $unit->id;
 			}
 
 			$units[$unit->id] = $unit;
 		}
-
-		$outOfStock = $outOfStock + $this->_outOfStock;
-
-		$this->_outOfStock = array_unique($outOfStock);
 
 		return $units;
 	}


### PR DESCRIPTION
The call to `array_unique()` in the out of stock array in the product selector was overwriting the values. This appears to be down to some lolPHP weird behaviour of the function: 

> Note that keys are preserved. array_unique() sorts the values treated as string at first, then will keep the first key encountered for every value, and ignore all following keys. It does not mean that the key of the first related value from the unsorted array will be kept.

So I guess the keys (0, 1, 2...) were being overwritten by the second array even though other array functions don't tend to work like this.

This fix uses the unit IDs as keys on the array to ensure that the values are unique instead of using this function