### PR TITLE
Make validation less strict on criteria form

### DIFF
--- a/src/Form/DiscountBenefitForm.php
+++ b/src/Form/DiscountBenefitForm.php
@@ -16,7 +16,6 @@ class DiscountBenefitForm extends Form\AbstractType
 			'label'    => 'ms.discount.discount.benefit.percentage.label',
 			'type'     => 'integer',
 			'constraints' => [
-				new Constraints\GreaterThan(['value' => 0]),
 				new Constraints\LessThanOrEqual(['value' => 100]),
 			]
 		]);
@@ -43,17 +42,17 @@ class DiscountBenefitForm extends Form\AbstractType
 
 	public function validate(Form\FormInterface $form)
 	{
-		$discountAmountsEmpty = true;
-		foreach($form->get('discountAmounts')->getData() as $currency => $amount) {
-			if(null !== $amount) {
-				$discountAmountsEmpty = false;
+		$discountAmounts = false;
+		foreach ($form->get('discountAmounts')->getData() as $currency => $amount) {
+			if ($amount) {
+				$discountAmounts = true;
 				break;
 			}
 		}
 
-		if (null !== $form->get('percentage')->getData() && !$discountAmountsEmpty) {
+		if ($form->get('percentage')->getData() && $discountAmounts) {
 			$form->addError(new Form\FormError('Please only fill in either a percentage OR a fixed discount.'));
-		} elseif (null === $form->get('percentage')->getData() && $discountAmountsEmpty && false === $form->get('freeShipping')->getData()) {
+		} elseif (!$form->get('percentage')->getData() && !$discountAmounts && false === $form->get('freeShipping')->getData()) {
 			$form->addError(new Form\FormError('Neither a percentage discount, nor a fixed discount amount, nor free shipping have been added to this discount.'));
 		}
 	}


### PR DESCRIPTION
This PR makes the validation less strict on the criteria form. Currently, if you save the criteria, you need to empty the 0s out of whichever discount type you aren't using, otherwise it will fail validation thinking that you are trying to save both.

I've also got rid of the double negatives in the variables of the form

To test, check validation on:

+ Saving discount criteria twice (should pass)
+ Saving both a discount percentage and fixed amount (should fail)
+ Saving just a percentage (should pass)
+ Saving just a fixed discount (should pass)
+ Saving a discount with just free shipping (should pass)
+ Saving a discount with no free shipping, percentage or fixed discount (should fail)